### PR TITLE
Modify nfd template to mount /sys

### DIFF
--- a/playbooks/roles/node-feature-discovery-setup/node-feature-discovery-daemonset.yaml
+++ b/playbooks/roles/node-feature-discovery-setup/node-feature-discovery-daemonset.yaml
@@ -30,3 +30,10 @@ spec:
         name: node-feature-discovery
         securityContext:
           privileged: true
+        volumeMounts:
+          - name: host-sys
+            mountPath: /host-sys 
+      volumes:
+        - name: host-sys
+          hostPath:
+            path: /sys


### PR DESCRIPTION
This commit mounts /sys on the host into the container. This is needed
to find out if selinux is enabled on the host.