### PR TITLE
Update the docker image in nfd template

### DIFF
--- a/playbooks/roles/node-feature-discovery-setup/node-feature-discovery-daemonset.yaml
+++ b/playbooks/roles/node-feature-discovery-setup/node-feature-discovery-daemonset.yaml
@@ -25,9 +25,11 @@ spec:
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
-              fieldPath: metadata.namespace
-        image: ravielluri/node_discovery:latest
+              fieldPath: spec.nodeName
+        image: quay.io/kubernetes_incubator/node-feature-discovery:v0.1.0
         name: node-feature-discovery
+        args:
+        - "--sleep-interval=60s"
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
This commit:
- updates the docker image to match the one in upstream since the
  the support to run node-feature-discovery as a daemonset has been
  merged.
- modifies the openshift template to stay in sync with the template
  in upstream repo.