### PR TITLE
race workaround

### DIFF
--- a/playbooks/roles/nvidia-container-runtime-hook/tasks/main.yaml
+++ b/playbooks/roles/nvidia-container-runtime-hook/tasks/main.yaml
@@ -17,6 +17,9 @@
     setype: container_file_t
     state: present
 
+- name: sleeping for a few seconds as there seems to be a race here.
+  shell: sleep 5
+
 - name: update SELinux type on nvidia device files
   shell: restorecon -v /dev/nvidia*
 


### PR DESCRIPTION
this is bizarre.  sometimes you see this:

```
root@ip-172-31-60-166: ~ # ls -alZ /dev/nvidia*                                       
crw-rw-rw-. root root unconfined_u:object_r:container_file_t:s0 /dev/nvidia0          
crw-rw-rw-. root root unconfined_u:object_r:container_file_t:s0 /dev/nvidia1          
crw-rw-rw-. root root unconfined_u:object_r:container_file_t:s0 /dev/nvidiactl        
crw-rw-rw-. root root system_u:object_r:container_file_t:s0 /dev/nvidia-modeset       
crw-rw-rw-. root root system_u:object_r:container_file_t:s0 /dev/nvidia-uvm           
crw-rw-rw-. root root system_u:object_r:container_file_t:s0 /dev/nvidia-uvm-tools     

```

The last 3 don't get labeled correctly, so the hook fails.  If you run restorecon again they get labeled correctly and everything works.