### PR TITLE
fix(scc): remove invalid defaultAddCapabilities setting

### DIFF
--- a/blog/gpu/device-plugin/nvidia-deviceplugin-scc.yaml
+++ b/blog/gpu/device-plugin/nvidia-deviceplugin-scc.yaml
@@ -8,8 +8,7 @@ allowedCapabilities:
 - '*'
 allowedFlexVolumes: null
 apiVersion: v1
-defaultAddCapabilities: 
-- '*'
+defaultAddCapabilities: null
 fsGroup:
   type: RunAsAny
 groups:

--- a/playbooks/roles/nvidia-device-plugin/files/nvidia-device-plugin-scc.yaml
+++ b/playbooks/roles/nvidia-device-plugin/files/nvidia-device-plugin-scc.yaml
@@ -8,8 +8,7 @@ allowedCapabilities:
 - '*'
 allowedFlexVolumes: null
 apiVersion: v1
-defaultAddCapabilities: 
-- '*'
+defaultAddCapabilities: null
 fsGroup:
   type: RunAsAny
 groups:


### PR DESCRIPTION
Change `defaultAddCapabilities` in each scc spec from the invalid
`['*']` to `null`. The API passes these values directly to the
container runtime without validation. Any pod inheriting these
add capabilities from the SCC will get an error from the runtime
with `Unknown capability to add: "Cap_*"`.

Bug: [#1636685](https://bugzilla.redhat.com/show_bug.cgi?id=1636685
Issue: [openshift/origin#19575](openshift/origin#19575)