### PR TITLE
Changes to variable-ize the runtime-hook and cuda repos.

### DIFF
--- a/playbooks/roles/nvidia-container-runtime-hook/defaults/main.yaml
+++ b/playbooks/roles/nvidia-container-runtime-hook/defaults/main.yaml
@@ -1,0 +1,3 @@
+nvidia_container_hook_repo_base_url: 'https://nvidia.github.io/'
+libnvidia_container_suffix: 'libnvidia-container/centos7/$basearch' 
+nvidia_container_runtime_suffix: 'nvidia-container-runtime/centos7/$basearch'

--- a/playbooks/roles/nvidia-container-runtime-hook/tasks/main.yaml
+++ b/playbooks/roles/nvidia-container-runtime-hook/tasks/main.yaml
@@ -1,6 +1,29 @@
 ---
-- name: install NVIDIA repo for container runtime hook
-  shell: yum-config-manager --add-repo=https://nvidia.github.io/nvidia-container-runtime/centos7/x86_64/nvidia-container-runtime.repo
+- name: libnvidia-container repo
+  yum_repository:
+    name: libnvidia-container
+    description: libnvidia-container
+    baseurl: '{{ nvidia_container_hook_repo_base_url }}{{ libnvidia_container_suffix }}'
+    repo_gpgcheck: true
+    gpgcheck: false
+    enabled: 1
+    gpgkey: https://nvidia.github.io/libnvidia-container/gpgkey
+    sslverify: 1
+    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    state: present
+
+- name: nvidia-container-runtime repo
+  yum_repository:
+    name: nvidia-container-runtime
+    description: nvidia-container-runtime
+    baseurl: '{{ nvidia_container_hook_repo_base_url }}{{ nvidia_container_runtime_suffix }}'
+    repo_gpgcheck: true
+    gpgcheck: false
+    enabled: 1
+    gpgkey: https://nvidia.github.io/nvidia-container-runtime/gpgkey
+    sslverify: 1
+    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    state: present
 
 - name: install nvidia-container-runtime-hook
   yum: name=nvidia-container-runtime-hook state=latest

--- a/playbooks/roles/nvidia-driver-install/defaults/main.yaml
+++ b/playbooks/roles/nvidia-driver-install/defaults/main.yaml
@@ -1,0 +1,2 @@
+cuda_driver_repo_base_url: 'http://developer.download.nvidia.com/' 
+cuda_driver_repo_suffix: 'compute/cuda/repos/rhel7/x86_64'

--- a/playbooks/roles/nvidia-driver-install/tasks/main.yaml
+++ b/playbooks/roles/nvidia-driver-install/tasks/main.yaml
@@ -6,8 +6,15 @@
 - name: install EPEL
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm state=present
 
-- name: install NVIDIA repo
-  yum: name=https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-repo-rhel7-9.1.85-1.x86_64.rpm state=present
+- name: cuda NVIDIA repository
+  yum_repository:
+    name: cuda
+    description: cuda
+    baseurl: '{{ cuda_driver_repo_base_url }}{{ cuda_driver_repo_suffix }}'
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/7fa2af80.pub
+    state: present
 
 - name: install NVIDIA drivers
   yum:  name={{item}} state=present


### PR DESCRIPTION
This PR changes the container-runtime-hook and cuda driver installation to use variable-based repository definitions via switching to the `yum_repository` ansible module instead of directly consuming either the NVIDIA repo definitions or the repo RPM.

The defaults are set to what comes directly from NVIDIA's repo defs/RPMs. But this allows one to substitute their own package mirror.

This change is useful for those who want to ensure that upstream changes do not break any automation or expected behaviors. NVIDIA's recent changes, as an example, to the driver RPMs for cuda caused these playbooks to fail when directly ran against the NVIDIA repos. If one was using a mirror, they would've been isolated from those changes.